### PR TITLE
Add Bareos roles

### DIFF
--- a/Dev_env.md
+++ b/Dev_env.md
@@ -1,0 +1,10 @@
+## Dev env
+In case you would like to set a dev environment for the testing purposes,  
+you could use a great role written by chrismeyersfsu.  
+The provision_docker [1] role creates a container and executes the playbook on it using the docker connection driver.  
+See the role readme for more details.
+
+Use the following Dockerfiles [2] for the tests.  
+
+[1] - https://github.com/chrismeyersfsu/provision_docker  
+[2] - https://github.com/MaxBab/dockerfiles

--- a/README.md
+++ b/README.md
@@ -1,2 +1,31 @@
-# bareos-ansible
-Bareos Director, DB, WebUI and clients configuration using Ansible
+Bareos Ansible
+--------------
+
+### Bareos - Backup Archiving REcovery Open Sourced
+Bareos (Backup Archiving Recovery Open Sourced) is a reliable, cross-network
+open source software for backup, archiving and recovery of data for all
+well-established operating systems. Emerged from the Bacula Project in 2010,
+Bareos was and is actively developed as a fork and enriched with lots of new features.
+
+The following repo contains number of Bareos roles.
+- Bareos basic - Sets Bareos repositories and holds common variables.
+- Bareos database - Installs one of the following databases: Postgresql/MariaDB.
+- Bareos Director - Installs and configures Bareos Director.
+- Bareos WebUI - Installs and configures Bareos WebUI.
+- Bareos clients - Installs and configures Bareos clients.
+
+The bareos-basic role contains common variables that used by other roles (ex. passwords).  
+Bareos-basic role triggered by the meta dependency of each role.
+
+Please, use the inventory.example file as a reference for the required groups.
+
+>Supported platforms:
+- Centos 6
+- Centos 7
+- Debian 8
+- Ubuntu 14.04
+
+#### TODO:
+- [x] Install and configure Bareos (Director, WebUI, Clients)
+- [ ] SSL support
+- [ ] Jobs creation

--- a/bareos.yml
+++ b/bareos.yml
@@ -1,0 +1,15 @@
+- name: Bareos database
+  hosts: director
+  roles:
+    - role: bareos-database
+
+- name: Bareos director
+  hosts: director
+  roles:
+    - role: bareos-director
+    - role: bareos-webui
+
+- name: Bareos clients
+  hosts: clients
+  roles:
+    - role: bareos-client

--- a/inventory.example
+++ b/inventory.example
@@ -1,0 +1,6 @@
+# Director group should hold one single server
+[director]
+bareos-server-name
+
+[clients]
+client-server-name

--- a/roles/bareos-basic/defaults/main.yml
+++ b/roles/bareos-basic/defaults/main.yml
@@ -1,0 +1,29 @@
+---
+
+################################################################
+### Database section                                         ###
+### Choose the database and version that should be installed ###
+### Supported databases: mariadb, postgres                   ###
+################################################################
+database: postgresql
+
+#database: mariadb
+#db_version: 10.1
+
+##################################################
+### Bareos database section ######################
+##################################################
+mariadb_root_password: "P@ssw0rd!"                      # This is an example password. Change it.
+mariadb_login_host: localhost
+
+##################################################
+### Bareos version ###############################
+### Choose the version of bareos if needed #######
+### Latest will be used by default ###############
+##################################################
+#bareos_version:
+
+webui_admin_user: admin
+webui_admin_pass: "P@ssw0rd!"                           # This is an example password. Change it.
+
+client_password: "P@ssw0rd!"                            # This is an example password. Change it.

--- a/roles/bareos-basic/tasks/main.yml
+++ b/roles/bareos-basic/tasks/main.yml
@@ -1,0 +1,30 @@
+---
+
+- name: Set Bareos repo for RHEL/CentOS
+  yum_repository:
+    name: bareos
+    description: 'bareos repo details'
+    baseurl: "http://download.bareos.org/bareos/release/{{ bareos_version | default('latest') }}/{{ ansible_distribution }}_{{ ansible_distribution_major_version }}/"
+    gpgcheck: yes
+    gpgkey: "http://download.bareos.org/bareos/release/{{ bareos_version | default('latest') }}/{{ ansible_distribution }}_{{ ansible_distribution_major_version }}/repodata/repomd.xml.key"
+    enabled: yes
+    state: present
+  when: ansible_os_family == 'RedHat'
+
+- block:
+    - name: Add a key for Bareos install for Debian/Ubuntu distribution
+      apt_key:
+        url: "http://download.bareos.org/bareos/release/{{ bareos_version | default('latest') }}/\
+        {% if ansible_distribution == 'Ubuntu' %}x{{ ansible_distribution }}_{{ ansible_distribution_version }}\
+        {% elif ansible_distribution == 'Debian' %}{{ ansible_distribution }}_{{ ansible_distribution_major_version }}.0{% endif %}/Release.key"
+        state: present
+
+    - name: Set Bareos repo for Debian/Ubuntu distribution
+      apt_repository:
+        repo: "deb http://download.bareos.org/bareos/release/{{ bareos_version | default('latest') }}/\
+        {% if ansible_distribution == 'Ubuntu' %}x{{ ansible_distribution }}_{{ ansible_distribution_version }}\
+        {% elif ansible_distribution == 'Debian' %}{{ ansible_distribution }}_{{ ansible_distribution_major_version }}.0{% endif %} /"
+        filename: bareos
+        update_cache: yes
+        state: present
+  when: ansible_os_family == 'Debian'

--- a/roles/bareos-client/handlers/main.yml
+++ b/roles/bareos-client/handlers/main.yml
@@ -1,0 +1,13 @@
+---
+
+- name: Restart Bareos-dir service
+  service:
+    name: bareos-dir
+    state: restarted
+  delegate_to: "{{ item }}"
+  with_items: "{{ groups['director'][0] }}"
+
+- name: Restart Bareos-fd service
+  service:
+    name: bareos-fd
+    state: restarted

--- a/roles/bareos-client/meta/main.yml
+++ b/roles/bareos-client/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - { role: bareos-basic }

--- a/roles/bareos-client/tasks/main.yml
+++ b/roles/bareos-client/tasks/main.yml
@@ -1,0 +1,26 @@
+---
+
+- name: Install Bareos client
+  package:
+    name: bareos-client
+    state: present
+
+- name: Start and enable Bareos client service
+  service:
+    name: "bareos-fd"
+    enabled: yes
+    state: started
+
+- name: Configure clients
+  template:
+    src: client-bareos-dir.conf.j2
+    dest: /etc/bareos/bareos-fd.d/director/bareos-dir.conf
+  notify: Restart Bareos-fd service
+
+- name: Configure clients on Director
+  template:
+    src: client-fd.conf.j2
+    dest: /etc/bareos/bareos-dir.d/client/{{ ansible_hostname }}-fd.conf
+  delegate_to: "{{ item }}"
+  with_items: "{{ groups['director'][0] }}"
+  notify: Restart Bareos-dir service

--- a/roles/bareos-client/templates/client-bareos-dir.conf.j2
+++ b/roles/bareos-client/templates/client-bareos-dir.conf.j2
@@ -1,0 +1,5 @@
+Director {
+  Name = bareos-dir
+  Password = {{ client_password }}
+  Description = "Allow the configured Director to access this file daemon."
+}

--- a/roles/bareos-client/templates/client-fd.conf.j2
+++ b/roles/bareos-client/templates/client-fd.conf.j2
@@ -1,0 +1,5 @@
+Client {
+  Name = {{ ansible_hostname }}
+  Address = {{ ansible_default_ipv4.address }}
+  Password = {{ client_password }}
+}

--- a/roles/bareos-database/meta/main.yml
+++ b/roles/bareos-database/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - { role: bareos-basic }

--- a/roles/bareos-database/tasks/main.yml
+++ b/roles/bareos-database/tasks/main.yml
@@ -1,0 +1,6 @@
+---
+
+- include_vars: '{{ ansible_os_family }}.yml'
+
+- name: Database installation
+  include: "{{ database }}_install.yml"

--- a/roles/bareos-database/tasks/mariadb_install.yml
+++ b/roles/bareos-database/tasks/mariadb_install.yml
@@ -1,0 +1,76 @@
+---
+
+- name: Upload MariaDB repo file for RedHat/CentOS distribution
+  yum_repository:
+    name: mariadb
+    description: 'MariaDB repository'
+    baseurl: http://yum.mariadb.org/{{ db_version }}/{{ ansible_distribution | lower }}{{ ansible_distribution_major_version }}-amd64
+    enabled: yes
+    gpgkey: https://yum.mariadb.org/RPM-GPG-KEY-MariaDB
+    gpgcheck: yes
+  when: ansible_os_family == 'RedHat'
+
+- block:
+    - name: Add a key for MariaDB install for Debian/Ubuntu distribution
+      apt_key:
+        keyserver: 'keyserver.ubuntu.com'
+        id: '0xcbcb082a1bb943db'
+
+    - name: Set MariaDB repo for Debian/Ubuntu distribution
+      apt_repository:
+        repo: "{{ item }}"
+        filename: mariadb
+        state: present
+      with_items:
+        - 'deb http://lon1.mirrors.digitalocean.com/mariadb/repo/{{ db_version }}/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} main'
+        - 'deb-src http://lon1.mirrors.digitalocean.com/mariadb/repo/{{ db_version }}/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} main'
+  when: ansible_os_family == 'Debian'
+
+- name: Install MariaDB
+  package:
+    name: '{{ item }}'
+    state: present
+  with_items: '{{ mariadb_packages }}'
+
+- name: Start MariaDB service and enable on boot
+  service:
+    name: mysql
+    enabled: yes
+    state: started
+
+- name: Delete anonymous MariaDB server user
+  mysql_user:
+    user: ""
+    host: "{{ ansible_hostname }}"
+    state: "absent"
+  ignore_errors: yes
+
+- name: Delete anonymous MariaDB server user for localhost
+  mysql_user:
+    user: ""
+    state: "absent"
+  ignore_errors: yes
+
+- name: Remove the MariaDB test database
+  mysql_db:
+    db: test
+    state: absent
+  ignore_errors: yes
+
+# 'localhost' needs to be the last item for idempotency, see
+# http://ansible.cc/docs/modules.html#mysql-user
+- name: Change root user password on first run
+  mysql_user:
+    login_user: root
+    login_password: ''
+    name: root
+    password: "{{ mariadb_root_password }}"
+    priv: '*.*:ALL,GRANT'
+    host: "{{ item }}"
+  with_items:
+    - "{{ ansible_hostname }}"
+    - 127.0.0.1
+    - ::1
+    - localhost
+  ignore_errors: yes
+  no_log: true

--- a/roles/bareos-database/tasks/postgresql_install.yml
+++ b/roles/bareos-database/tasks/postgresql_install.yml
@@ -1,0 +1,34 @@
+---
+
+# APT module does not updating the cache by default and since
+# package module used instead, the cache should be updated previously.
+- name: Update apt cache
+  apt:
+    update_cache: yes
+  when: ansible_os_family == 'Debian'
+
+- name: Install Postgres
+  package:
+    name: '{{ item }}'
+    state: present
+  with_items: '{{ postgres_packages }}'
+  register: bareos_install
+
+- name: Init new Postgresql db cluster on RHEL/CentOS 7
+  command: /usr/bin/postgresql-setup initdb
+  when:
+    - bareos_install|changed
+    - ansible_os_family == 'RedHat' and ansible_distribution_major_version == '7'
+
+- name: Init new Postgresql db cluster on RHEL/CentOS 6
+  command: service postgresql initdb
+  when:
+    - bareos_install|changed
+    - ansible_os_family == 'RedHat'
+    - ansible_distribution_major_version == '6'
+
+- name: Start and enable Postgresql service
+  service:
+    name: postgresql
+    enabled: yes
+    state: started

--- a/roles/bareos-database/vars/Debian.yml
+++ b/roles/bareos-database/vars/Debian.yml
@@ -1,0 +1,9 @@
+---
+
+mariadb_packages:
+  - mariadb-server
+  - python-mysqldb
+
+postgres_packages:
+  - postgresql
+  - postgresql-contrib

--- a/roles/bareos-database/vars/RedHat.yml
+++ b/roles/bareos-database/vars/RedHat.yml
@@ -1,0 +1,13 @@
+---
+
+mariadb_packages:
+  - MariaDB-server
+  - MariaDB-client
+  - MariaDB-common
+  - MariaDB-devel
+  - MariaDB-compat
+  - MySQL-python
+
+postgres_packages:
+  - postgresql-server
+  - postgresql-contrib

--- a/roles/bareos-director/handlers/main.yml
+++ b/roles/bareos-director/handlers/main.yml
@@ -1,0 +1,6 @@
+---
+
+- name: Restart Bareos-fd service
+  service:
+    name: bareos-fd
+    state: restarted

--- a/roles/bareos-director/meta/main.yml
+++ b/roles/bareos-director/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - { role: bareos-basic }

--- a/roles/bareos-director/tasks/bareos-client.yml
+++ b/roles/bareos-director/tasks/bareos-client.yml
@@ -1,0 +1,26 @@
+---
+
+- name: Install Bareos client
+  package:
+    name: bareos-client
+    state: present
+
+- name: Start and enable Bareos client service
+  service:
+    name: "bareos-fd"
+    enabled: yes
+    state: started
+
+- name: Modify default director client
+  lineinfile:
+    path: /etc/bareos/bareos-dir.d/client/bareos-fd.conf
+    regexp: '^(.*)Password(.*)$'
+    line: '  Password = {{ client_password }}'
+  delegate_to: "{{ item }}"
+  with_items: "{{ groups['director'][0] }}"
+
+- name: Configure clients
+  template:
+    src: client-bareos-dir.conf.j2
+    dest: /etc/bareos/bareos-fd.d/director/bareos-dir.conf
+  notify: Restart Bareos-fd service

--- a/roles/bareos-director/tasks/main.yml
+++ b/roles/bareos-director/tasks/main.yml
@@ -1,0 +1,63 @@
+---
+
+- name: Install Bareos
+  package:
+    name: '{{ item }}'
+    state: present
+  with_items:
+    - "bareos"
+    - "bareos-database-{% if database == 'mariadb' %}mysql{% else %}postgresql{% endif %}"
+  register: bareos_install
+
+- name: Ensure proper database catalog connection
+  replace:
+    path: /etc/bareos/bareos-dir.d/catalog/MyCatalog.conf
+    regexp: 'dbdriver.*'
+    replace: "dbdriver = {% if database == 'mariadb' %}mysql{% else %}postgresql{% endif %}"
+
+- name: Prepare database for MariaDB
+  command: "{{ item }} mysql --user=root --password='{{ mariadb_root_password }}'"
+  no_log: true
+  with_items:
+    - '/usr/lib/bareos/scripts/create_bareos_database'
+    - '/usr/lib/bareos/scripts/make_bareos_tables'
+    - '/usr/lib/bareos/scripts/grant_bareos_privileges'
+  when: bareos_install|changed and database == 'mariadb'
+
+- block:
+    - name: Install psycopg2 package for Postgresql management
+      package:
+        name: python-psycopg2
+        state: present
+
+    # On Ubuntu, during Bareos install, 'bareos' db created
+    # while using postgresql db. This cause db prepare scripts
+    # to fail. Because of this, removing the db before script exec.
+    - name: Remove bareos database
+      postgresql_db:
+        name: bareos
+        state: absent
+      become: true
+      become_user: postgres
+
+    - name: Prepare database for Postgresql
+      command: "{{ item }} postgresql"
+      with_items:
+        - '/usr/lib/bareos/scripts/create_bareos_database'
+        - '/usr/lib/bareos/scripts/make_bareos_tables'
+        - '/usr/lib/bareos/scripts/grant_bareos_privileges'
+      become: true
+      become_user: postgres
+  when: bareos_install|changed and database == 'postgresql'
+
+- name: Start and enable Bareos services
+  service:
+    name: "bareos-{{ item }}"
+    enabled: yes
+    state: started
+  with_items:
+    - dir
+    - sd
+
+- name: Configure client on Bareos director
+  include: bareos-client.yml

--- a/roles/bareos-director/templates/client-bareos-dir.conf.j2
+++ b/roles/bareos-director/templates/client-bareos-dir.conf.j2
@@ -1,0 +1,5 @@
+Director {
+  Name = bareos-dir
+  Password = {{ client_password }}
+  Description = "Allow the configured Director to access this file daemon."
+}

--- a/roles/bareos-director/templates/client-fd.conf.j2
+++ b/roles/bareos-director/templates/client-fd.conf.j2
@@ -1,0 +1,5 @@
+Client {
+  Name = {{ ansible_hostname }}
+  Address = {{ ansible_default_ipv4.address }}
+  Password = {{ client_password }}
+}

--- a/roles/bareos-webui/handlers/main.yml
+++ b/roles/bareos-webui/handlers/main.yml
@@ -1,0 +1,13 @@
+---
+
+- name: Restart Apache "RedHat"
+  service:
+    name: httpd
+    enabled: yes
+    state: restarted
+
+- name: Restart Apache "Debian"
+  service:
+    name: apache2
+    enabled: yes
+    state: restarted

--- a/roles/bareos-webui/meta/main.yml
+++ b/roles/bareos-webui/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - { role: bareos-basic }

--- a/roles/bareos-webui/tasks/main.yml
+++ b/roles/bareos-webui/tasks/main.yml
@@ -1,0 +1,34 @@
+---
+
+- name: Install WebUI package
+  package:
+    name: bareos-webui
+    state: present
+  notify:
+    - Restart Apache "{{ ansible_os_family }}"
+
+- meta: flush_handlers
+
+- name: Create WebUI admin user
+  template:
+    src: webui-admin.conf.j2
+    dest: /etc/bareos/bareos-dir.d/console/admin.conf
+    owner: bareos
+    group: bareos
+    mode: 0640
+
+- block:
+    - name: Install Selinux management package
+      yum:
+        name: "{{ item }}"
+        state: present
+      with_items:
+        - libselinux-python
+        - libsemanage-python
+
+    - name: Set Selinux config
+      seboolean:
+        name: httpd_can_network_connect
+        state: yes
+        persistent: yes
+  when: ansible_os_family == 'RedHat' and ansible_selinux != false and ansible_selinux.status != 'disabled'

--- a/roles/bareos-webui/templates/webui-admin.conf.j2
+++ b/roles/bareos-webui/templates/webui-admin.conf.j2
@@ -1,0 +1,5 @@
+Console {
+Name = "{{ webui_admin_user }}"
+Password = "{{ webui_admin_pass }}"
+Profile = "webui-admin"
+}


### PR DESCRIPTION
Adding the following Bareos roles:
- Bareos-basic - Sets Bareos repositories and holds common variables.
- Bareos database - Installs one of the following databases: Postgresql/MariaDB.
- Bareos Director - Installs and configures Bareos Director.
- Bareos WebUI - Installs and configures Bareos WebUI.
- Bareos clients - Installs and configures Bareos clients.